### PR TITLE
feat: Explicit autowiring of crates

### DIFF
--- a/nix/modules/crate.nix
+++ b/nix/modules/crate.nix
@@ -124,7 +124,7 @@
 
           packages = lib.mkOption {
             type = lib.types.lazyAttrsOf lib.types.package;
-            default = {
+            default = lib.optionalAttrs config.autoWire {
               ${name} = config.crane.outputs.drv.crate;
               "${name}-doc" = config.crane.outputs.drv.doc;
             };
@@ -132,7 +132,7 @@
 
           checks = lib.mkOption {
             type = lib.types.lazyAttrsOf lib.types.package;
-            default = lib.optionalAttrs crane.clippy.enable {
+            default = lib.optionalAttrs (config.autoWire && crane.clippy.enable) {
               "${name}-clippy" = config.crane.outputs.drv.clippy;
             };
           };

--- a/nix/modules/crate.nix
+++ b/nix/modules/crate.nix
@@ -76,6 +76,8 @@
           version = cargoToml.package.version;
 
           # Crane builder
+          # NOTE: Is it worth exposing this entire attrset as a readOnly module
+          # option?
           craneBuild = rec {
             args = crane.args // {
               inherit src version;
@@ -102,21 +104,39 @@
           };
         in
         {
+          drv = {
+            crate = lib.mkOption {
+              type = lib.types.package;
+              description = "The Nix package for the Rust crate";
+              default = craneBuild.package;
+            };
+            doc = lib.mkOption {
+              type = lib.types.package;
+              description = "The Nix package for the Rust crate documentation";
+              default = craneBuild.doc;
+            };
+            clippy = lib.mkOption {
+              type = lib.types.package;
+              description = "The Nix package for the Rust crate clippy check";
+              default = craneBuild.check;
+            };
+          };
+
           packages = lib.mkOption {
             type = lib.types.lazyAttrsOf lib.types.package;
             default = {
-              ${name} = craneBuild.package;
-              "${name}-doc" = craneBuild.doc;
+              ${name} = config.crane.outputs.drv.crate;
+              "${name}-doc" = config.crane.outputs.drv.doc;
             };
           };
 
           checks = lib.mkOption {
             type = lib.types.lazyAttrsOf lib.types.package;
             default = lib.optionalAttrs crane.clippy.enable {
-              "${name}-clippy" = craneBuild.check;
+              "${name}-clippy" = config.crane.outputs.drv.clippy;
             };
           };
         };
-      };
+    };
   };
 }

--- a/nix/modules/crate.nix
+++ b/nix/modules/crate.nix
@@ -20,6 +20,16 @@
       type = lib.types.attrsOf lib.types.raw;
       default = builtins.fromTOML (builtins.readFile ("${config.path}/Cargo.toml"));
     };
+    autoWire = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Autowire the packages and checks for this crate on to the flake output.
+
+        Generally, not all workspace creates need to be wired, only the ones
+        that the user actually uses need to be.
+      '';
+    };
     crane = {
       args = {
         buildInputs = lib.mkOption {
@@ -94,6 +104,6 @@
             };
           };
         };
-    };
+      };
   };
 }

--- a/nix/modules/crate.nix
+++ b/nix/modules/crate.nix
@@ -20,14 +20,27 @@
       type = lib.types.attrsOf lib.types.raw;
       default = builtins.fromTOML (builtins.readFile ("${config.path}/Cargo.toml"));
     };
+    hasBinaries = lib.mkOption {
+      type = lib.types.bool;
+      readOnly = true;
+      description = ''
+        Whether the crate has binaries or not.
+
+        See <https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries>
+      '';
+      default =
+        lib.pathIsRegularFile "${config.path}/src/main.rs" ||
+        lib.pathIsDirectory "${config.path}/src/bin" ||
+        lib.hasAttr "bin" config.cargoToml;
+    };
     autoWire = lib.mkOption {
       type = lib.types.bool;
-      default = false;
+      default = config.hasBinaries;
+      defaultText = "true if the crate has binaries, false otherwise";
       description = ''
         Autowire the packages and checks for this crate on to the flake output.
 
-        Generally, not all workspace creates need to be wired, only the ones
-        that the user actually uses need to be.
+        By default, crates with binaries will have their packages and checks wired.
       '';
     };
     crane = {

--- a/nix/modules/default-crates.nix
+++ b/nix/modules/default-crates.nix
@@ -30,6 +30,7 @@
       {
         ${cargoToml.package.name} = {
           path = lib.mkDefault src;
+          autoWire = true;
         };
       };
 }


### PR DESCRIPTION
On a multi-crate workspace, disable autowiring of crates by default, unless the crate has binaries. Otherwise, they will be forced to configure each library crate to build in Nix separately (via specifying `buildInputs`) which is quite unnecessary if only a handful of crates need to be exposed in the flake.

The user can toggle `autoWire` on or off for individual crates. The packages are nevertheless exposed as options.

- [x] Test in real-world case: https://github.com/juspay/superposition/pull/156
- [x] Provide a `outputs.package` regardless of autowiring for manual wiring?
- [x] Disable or enable autoWire by default? (see comment below)

