### PR TITLE
feat: Allow importing of `crate.nix` automatically

### DIFF
--- a/nix/modules/default-crates.nix
+++ b/nix/modules/default-crates.nix
@@ -16,15 +16,27 @@
               lib.cleanSourceWith {
                 name = builtins.baseNameOf pathString;
                 src = "${src}/${pathString}";
+                # TODO(DRY): Consolidate with that of flake-module.nix
                 filter = path: type:
+                  (config.rust-project.crateNixFile != null && lib.hasSuffix "/${config.rust-project.crateNixFile}" path) ||
                   (config.rust-project.crane-lib.filterCargoSources path type);
               };
             cargoPath = "${path}/Cargo.toml";
             cargoToml = builtins.fromTOML (builtins.readFile cargoPath);
             name = cargoToml.package.name;
+            crateNixFilePath =
+              if config.rust-project.crateNixFile == null
+              then null
+              else
+                let p = "${path}/${config.rust-project.crateNixFile}"; in
+                if lib.pathIsRegularFile p then p else null;
           in
           acc // {
             ${name} = {
+              # Import the .nix file from the crate directory, if asked for.
+              imports = lib.optionals (crateNixFilePath != null) [
+                (builtins.traceVerbose "rust-flake: Using ${crateNixFilePath}" crateNixFilePath)
+              ];
               path = lib.mkDefault path;
             };
           }


### PR DESCRIPTION
By default, nothing happens - unless the user sets the `crateNixFile` option.

This is useful in multi-crate workspace, where each crate wants to define the Nix for it in its own directory.