### PR TITLE
Make option docs evaluate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,21 @@
     crane.url = "github:ipetkov/crane";
     crane.inputs.nixpkgs.follows = "nixpkgs";
   };
-  outputs = { rust-overlay, crane, ... }: {
+  outputs = { rust-overlay, crane, ... }:
+  let
+    # Preserve name and key of the module file for dedup and error message locations
+    import' =
+      modulePath: staticArg:
+        {
+          key = toString modulePath;
+          _file = toString modulePath;
+          imports = [ (import modulePath staticArg) ];
+        };
+  in
+  {
     flakeModules = {
-      default = import ./nix/modules/flake-module.nix { inherit rust-overlay crane; };
-      nixpkgs = import ./nix/modules/nixpkgs.nix;
+      default = import' ./nix/modules/flake-module.nix { inherit rust-overlay crane; };
+      nixpkgs = ./nix/modules/nixpkgs.nix;
     };
     nixci.default =
       let

--- a/nix/modules/crate.nix
+++ b/nix/modules/crate.nix
@@ -18,7 +18,10 @@
     };
     cargoToml = lib.mkOption {
       type = lib.types.attrsOf lib.types.raw;
-      default = builtins.fromTOML (builtins.readFile ("${config.path}/Cargo.toml"));
+      default = builtins.fromTOML (builtins.readFile (config.path + "/Cargo.toml"));
+      defaultText = lib.literalExpression ''
+        fromTOML (readFile (path + "/Cargo.toml"))
+      '';
     };
     autoWire =
       let
@@ -48,6 +51,9 @@
             pkg-config
             makeWrapper
           ];
+          defaultText = lib.literalExample ''
+            with pkgs; [ pkg-config makeWrapper ]
+          '';
           description = "nativeBuildInputs for the cargo package";
         };
       };
@@ -113,16 +119,19 @@
               type = lib.types.package;
               description = "The Nix package for the Rust crate";
               default = craneBuild.package;
+              defaultText = lib.literalMD "_computed with crane_";
             };
             doc = lib.mkOption {
               type = lib.types.package;
               description = "The Nix package for the Rust crate documentation";
               default = craneBuild.doc;
+              defaultText = lib.literalMD "_computed with crane_";
             };
             clippy = lib.mkOption {
               type = lib.types.package;
               description = "The Nix package for the Rust crate clippy check";
               default = craneBuild.check;
+              defaultText = lib.literalMD "_computed with crane_";
             };
           };
 
@@ -135,6 +144,15 @@
               (lib.optionalAttrs (lib.elem "doc" config.autoWire) {
                 "${name}-doc" = config.crane.outputs.drv.doc;
               });
+            defaultText = lib.literalMD ''
+              lib.mergeAttrs
+                (optionalAttrs (elem "crate" config.autoWire) {
+                  "''${name}" = config.crane.outputs.drv.crate;
+                })
+                (optionalAttrs (elem "doc" config.autoWire) {
+                  "''${name}-doc" = config.crane.outputs.drv.doc;
+                })
+            '';
           };
 
           checks = lib.mkOption {
@@ -142,6 +160,11 @@
             default = lib.optionalAttrs (lib.elem "clippy" config.autoWire && crane.clippy.enable) {
               "${name}-clippy" = config.crane.outputs.drv.clippy;
             };
+            defaultText = lib.literalExample ''
+              optionalAttrs (elem "clippy" config.autoWire && crane.clippy.enable) {
+                "''${name}-clippy" = config.crane.outputs.drv.clippy;
+              }
+            '';
           };
         };
     };

--- a/nix/modules/crate.nix
+++ b/nix/modules/crate.nix
@@ -15,9 +15,11 @@
   options = {
     path = lib.mkOption {
       type = lib.types.path;
+      description = "The path to the crate folder";
     };
     cargoToml = lib.mkOption {
       type = lib.types.attrsOf lib.types.raw;
+      description = "The parsed Cargo.toml file";
       default = builtins.fromTOML (builtins.readFile (config.path + "/Cargo.toml"));
       defaultText = lib.literalExpression ''
         fromTOML (readFile (path + "/Cargo.toml"))
@@ -137,6 +139,7 @@
 
           packages = lib.mkOption {
             type = lib.types.lazyAttrsOf lib.types.package;
+            description = "All Nix packages for the Rust crate";
             default = lib.mergeAttrs
               (lib.optionalAttrs (lib.elem "crate" config.autoWire) {
                 ${name} = config.crane.outputs.drv.crate;
@@ -157,6 +160,7 @@
 
           checks = lib.mkOption {
             type = lib.types.lazyAttrsOf lib.types.package;
+            description = "All Nix flake checks for the Rust crate";
             default = lib.optionalAttrs (lib.elem "clippy" config.autoWire && crane.clippy.enable) {
               "${name}-clippy" = config.crane.outputs.drv.clippy;
             };

--- a/nix/modules/flake-module.nix
+++ b/nix/modules/flake-module.nix
@@ -31,6 +31,7 @@ in
             crane-lib = lib.mkOption {
               type = lib.types.lazyAttrsOf lib.types.raw;
               default = (rustFlakeInputs.crane.mkLib pkgs).overrideToolchain config.rust-project.toolchain;
+              defaultText = lib.literalExpression "computed from `rust-flake.inputs.crane` and [`perSystem.rust-project.toolchain`](#opt-perSystem.rust-project.toolchain)";
             };
             toolchain = lib.mkOption {
               type = lib.types.package;
@@ -42,6 +43,9 @@ in
                   "clippy"
                 ];
               };
+              defaultText = lib.literalMD ''
+                Based on the `rust-toolchain.toml` file in the flake directory
+              '';
             };
 
             crateNixFile = lib.mkOption {
@@ -67,6 +71,9 @@ in
                   (config.rust-project.crane-lib.filterCargoSources path type)
                 ;
               };
+              defaultText = lib.literalMD ''
+                Files in this flake (`self`) filtered by crane
+              '';
             };
 
             cargoToml = lib.mkOption {
@@ -75,6 +82,9 @@ in
                 Cargo.toml parsed in Nix
               '';
               default = builtins.fromTOML (builtins.readFile (self + /Cargo.toml));
+              defaultText = lib.literalExpression ''
+                fromTOML (readFile (self + "/Cargo.toml"))
+              '';
             };
           };
         };

--- a/nix/modules/flake-module.nix
+++ b/nix/modules/flake-module.nix
@@ -30,6 +30,9 @@ in
 
             crane-lib = lib.mkOption {
               type = lib.types.lazyAttrsOf lib.types.raw;
+              description = ''
+                The value of `crane.mkLib pkgs` providing crane library functions
+              '';
               default = (rustFlakeInputs.crane.mkLib pkgs).overrideToolchain config.rust-project.toolchain;
               defaultText = lib.literalExpression "computed from `rust-flake.inputs.crane` and [`perSystem.rust-project.toolchain`](#opt-perSystem.rust-project.toolchain)";
             };


### PR DESCRIPTION
Required for https://github.com/hercules-ci/flake.parts-website/pull/1070 to evaluate

> Some defaults should probably be normal definitions or `lib.mkDefault`
> definitions in the config section. They don't all make sense to be
> documented defaults.
>
> However, I've solved it with some less than optimal descriptions in
> order not to move code around. Maybe I should have just moved it?

A few options are still missing descriptions, as shown by the build log:

```
nix build github:srid/flake.parts-website/rust-flake#checks.x86_64-linux.linkcheck --override-input rust-flake . --no-show-trace -vL
[...]
options.json> error: option perSystem.rust-project.crane-lib has no description
options.json> error: option perSystem.rust-project.crates.<name>.cargoToml has no description
options.json> error: option perSystem.rust-project.crates.<name>.crane.outputs.checks has no description
options.json> error: option perSystem.rust-project.crates.<name>.crane.outputs.packages has no description
options.json> error: option perSystem.rust-project.crates.<name>.path has no description
```

This PR is meant to get you across the initial bump of making it eval, so we can get the docs to build. Could you review and complete it? Feel free to push to my fork's branch.

Some general recommendations:
- Some definitions where a documented default isn't needed could be `lib.mkDefault` in `config` instead
- Please add a command like the above to CI (replacing srid's branch by upstream when merged)
- Always add a `defaultText` if the `default` isn't a constant literal / references any variable, option or function

