### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1736566337,
-        "narHash": "sha256-SC0eDcZPqISVt6R0UfGPyQLrI0+BppjjtQ3wcSlk0oI=",
+        "lastModified": 1739053031,
+        "narHash": "sha256-LrMDRuwAlRFD2T4MgBSRd1s2VtOE+Vl1oMCNu3RpPE0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "9172acc1ee6c7e1cbafc3044ff850c568c75a5a3",
+        "rev": "112e6591b2d6313b1bd05a80a754a8ee42432a7e",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715447595,
-        "narHash": "sha256-VsVAUQOj/cS1LCOmMjAGeRksXIAdPnFIjCQ0XLkCsT0=",
+        "lastModified": 1739020877,
+        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "062ca2a9370a27a35c524dc82d540e6e9824b652",
+        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736700680,
-        "narHash": "sha256-9gmWIb8xsycWHEYpd2SiVIAZnUULX6Y+IMMZBcDUCQU=",
+        "lastModified": 1739154531,
+        "narHash": "sha256-QGeN6e0nMJlNLzm3Y2A7P6riXhQXMeCXLZ7yajZYFQM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5d1865c0da63b4c949f383d982b6b43519946e8f",
+        "rev": "035dac86ab7ce5c1e8a4d59dfe85e6911a3526ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
❯ : nix flake update crane rust-overlay nixpkgs
warning: updating lock file '/Users/srid/code/rust-flake/flake.lock':
• Updated input 'crane':
    'github:ipetkov/crane/9172acc1ee6c7e1cbafc3044ff850c568c75a5a3?narHash=sha256-SC0eDcZPqISVt6R0UfGPyQLrI0%2BBppjjtQ3wcSlk0oI%3D' (2025-01-11)
  → 'github:ipetkov/crane/112e6591b2d6313b1bd05a80a754a8ee42432a7e?narHash=sha256-LrMDRuwAlRFD2T4MgBSRd1s2VtOE%2BVl1oMCNu3RpPE0%3D' (2025-02-08)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/062ca2a9370a27a35c524dc82d540e6e9824b652?narHash=sha256-VsVAUQOj/cS1LCOmMjAGeRksXIAdPnFIjCQ0XLkCsT0%3D' (2024-05-11)
  → 'github:nixos/nixpkgs/a79cfe0ebd24952b580b1cf08cd906354996d547?narHash=sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y%3D' (2025-02-08)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/5d1865c0da63b4c949f383d982b6b43519946e8f?narHash=sha256-9gmWIb8xsycWHEYpd2SiVIAZnUULX6Y%2BIMMZBcDUCQU%3D' (2025-01-12)
  → 'github:oxalica/rust-overlay/035dac86ab7ce5c1e8a4d59dfe85e6911a3526ea?narHash=sha256-QGeN6e0nMJlNLzm3Y2A7P6riXhQXMeCXLZ7yajZYFQM%3D' (2025-02-10)
```