### PR TITLE
feat: glob support for workspace.members

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,26 @@
         "type": "github"
       }
     },
+    "globset": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744379919,
+        "narHash": "sha256-ieaQegt7LdMDFweeHhRaUQFYyF0U3pWD/XiCvq5L5U8=",
+        "owner": "pdtpartners",
+        "repo": "globset",
+        "rev": "4e21c96ab1259b8cd864272f96a8891b589c8eda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pdtpartners",
+        "repo": "globset",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1745234285,
@@ -34,6 +54,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "globset": "globset",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,12 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
     crane.url = "github:ipetkov/crane";
+    globset = {
+      url = "github:pdtpartners/globset";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
   };
-  outputs = { rust-overlay, crane, ... }:
+  outputs = { rust-overlay, crane, globset, ... }:
     let
       # Preserve name and key of the module file for dedup and error message locations
       import' =
@@ -19,7 +23,7 @@
     in
     {
       flakeModules = {
-        default = import' ./nix/modules/flake-module.nix { inherit rust-overlay crane; };
+        default = import' ./nix/modules/flake-module.nix { inherit rust-overlay crane globset; };
         nixpkgs = ./nix/modules/nixpkgs.nix;
       };
       nixci.default =

--- a/nix/modules/default-crates.nix
+++ b/nix/modules/default-crates.nix
@@ -14,7 +14,7 @@
           let
             path =
               lib.cleanSourceWith {
-                name = if pathString == "." then cargoToml.package.name else builtins.baseNameOf pathString;
+                name = if pathString == "." then cargoToml.package.name else builtins.baseNameOf pathString; # "." maps to root package
                 src = "${src}/${pathString}";
                 # TODO(DRY): Consolidate with that of flake-module.nix
                 filter = path: type:

--- a/nix/modules/default-crates.nix
+++ b/nix/modules/default-crates.nix
@@ -5,7 +5,6 @@
   rust-project.crates =
     let
       inherit (config.rust-project) cargoToml src globset;
-      expandGlobs = members: lib.fileset.toList (globset.lib.globs src members);
       topCargoToml = cargoToml;
     in
     if lib.hasAttr "workspace" cargoToml
@@ -44,7 +43,7 @@
           }
         )
         { }
-        (expandGlobs cargoToml.workspace.members)
+        (lib.fileset.toList (globset.lib.globs src cargoToml.workspace.members))
     else
     # Read single package crate from top-level Cargo.toml
       {

--- a/nix/modules/default-crates.nix
+++ b/nix/modules/default-crates.nix
@@ -5,7 +5,6 @@
   rust-project.crates =
     let
       inherit (config.rust-project) cargoToml src globset;
-      topCargoToml = cargoToml;
     in
     if lib.hasAttr "workspace" cargoToml
     then
@@ -15,16 +14,16 @@
           let
             path =
               lib.cleanSourceWith {
-                name = if pathString == "." then topCargoToml.package.name else builtins.baseNameOf pathString;
+                name = if pathString == "." then cargoToml.package.name else builtins.baseNameOf pathString;
                 src = "${src}/${pathString}";
                 # TODO(DRY): Consolidate with that of flake-module.nix
                 filter = path: type:
                   (config.rust-project.crateNixFile != null && lib.hasSuffix "/${config.rust-project.crateNixFile}" path) ||
                   (config.rust-project.crane-lib.filterCargoSources path type);
               };
-            cargoPath = "${path}/Cargo.toml";
-            cargoToml = builtins.fromTOML (builtins.readFile cargoPath);
-            name = cargoToml.package.name;
+            crateCargoPath = "${path}/Cargo.toml";
+            crateCargoToml = builtins.fromTOML (builtins.readFile crateCargoPath);
+            name = crateCargoToml.package.name;
             crateNixFilePath =
               if config.rust-project.crateNixFile == null
               then null

--- a/nix/modules/flake-module.nix
+++ b/nix/modules/flake-module.nix
@@ -31,6 +31,11 @@ in
 
             globset = lib.mkOption {
               default = rustFlakeInputs.globset;
+              internal = true;
+              readOnly = true;
+              description = ''
+                Reference to the globset flake input.
+              '';
             };
 
             crane-lib = lib.mkOption {
@@ -41,7 +46,6 @@ in
               default = (rustFlakeInputs.crane.mkLib pkgs).overrideToolchain config.rust-project.toolchain;
               defaultText = lib.literalExpression "computed from `rust-flake.inputs.crane` and [`perSystem.rust-project.toolchain`](#opt-perSystem.rust-project.toolchain)";
             };
-
             toolchain = lib.mkOption {
               type = lib.types.package;
               description = "Rust toolchain to use for the rust-project package";

--- a/nix/modules/flake-module.nix
+++ b/nix/modules/flake-module.nix
@@ -29,6 +29,10 @@ in
               });
             };
 
+            globset = lib.mkOption {
+              default = rustFlakeInputs.globset;
+            };
+
             crane-lib = lib.mkOption {
               type = lib.types.lazyAttrsOf lib.types.raw;
               description = ''
@@ -37,6 +41,7 @@ in
               default = (rustFlakeInputs.crane.mkLib pkgs).overrideToolchain config.rust-project.toolchain;
               defaultText = lib.literalExpression "computed from `rust-flake.inputs.crane` and [`perSystem.rust-project.toolchain`](#opt-perSystem.rust-project.toolchain)";
             };
+
             toolchain = lib.mkOption {
               type = lib.types.package;
               description = "Rust toolchain to use for the rust-project package";


### PR DESCRIPTION
- special handling for "."

--- 



The issue I'm having is with `["crates/*"]` which seems pretty ubiquitous. 
Also resolves https://github.com/juspay/rust-flake/issues/31

https://doc.rust-lang.org/cargo/reference/workspaces.html#the-members-and-exclude-fields
Its not clear to be whether "typical glob patterns" suggests it doesn't support the "atypical" ones? 
Rather than inlining full glob pattern handling, or supporting only a piece of it I brought in a new input. 

My understanding of scoping and `imports` in nix/flakes/parts is weak. 
Having stared at it for too long, I think its like this... ? 
