### PR TITLE
refactor: switches `nixci` to `om ci`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.direnv
 /just-flake.just
 /.pre-commit-config.yaml
+result

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         default = import' ./nix/modules/flake-module.nix { inherit rust-overlay crane globset; };
         nixpkgs = ./nix/modules/nixpkgs.nix;
       };
-      nixci.default =
+      om.ci.default =
         let
           overrideInputs = {
             rust-flake = ./.;


### PR DESCRIPTION
> nixci has been superceded by omnixl; you should use `om ci` instead.

^ In favor of above