### PR TITLE
Revert globset flake (#34) and implement custom glob handling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,26 +15,6 @@
         "type": "github"
       }
     },
-    "globset": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1744379919,
-        "narHash": "sha256-ieaQegt7LdMDFweeHhRaUQFYyF0U3pWD/XiCvq5L5U8=",
-        "owner": "pdtpartners",
-        "repo": "globset",
-        "rev": "4e21c96ab1259b8cd864272f96a8891b589c8eda",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pdtpartners",
-        "repo": "globset",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1751271578,
@@ -54,7 +34,6 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "globset": "globset",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,8 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
     crane.url = "github:ipetkov/crane";
-    globset = {
-      url = "github:pdtpartners/globset";
-      inputs.nixpkgs-lib.follows = "nixpkgs";
-    };
   };
-  outputs = { rust-overlay, crane, globset, ... }:
+  outputs = { rust-overlay, crane, ... }:
     let
       # Preserve name and key of the module file for dedup and error message locations
       import' =
@@ -23,7 +19,7 @@
     in
     {
       flakeModules = {
-        default = import' ./nix/modules/flake-module.nix { inherit rust-overlay crane globset; };
+        default = import' ./nix/modules/flake-module.nix { inherit rust-overlay crane; };
         nixpkgs = ./nix/modules/nixpkgs.nix;
       };
       om.ci.default =

--- a/nix/modules/default-crates.nix
+++ b/nix/modules/default-crates.nix
@@ -4,7 +4,7 @@
 {
   rust-project.crates =
     let
-      inherit (config.rust-project) cargoToml src globset;
+      inherit (config.rust-project) cargoToml src;
     in
     if lib.hasAttr "workspace" cargoToml
     then
@@ -14,16 +14,16 @@
           let
             path =
               lib.cleanSourceWith {
-                name = if pathString == "." then cargoToml.package.name else builtins.baseNameOf pathString; # "." maps to root package
+                name = builtins.baseNameOf pathString;
                 src = "${src}/${pathString}";
                 # TODO(DRY): Consolidate with that of flake-module.nix
                 filter = path: type:
                   (config.rust-project.crateNixFile != null && lib.hasSuffix "/${config.rust-project.crateNixFile}" path) ||
                   (config.rust-project.crane-lib.filterCargoSources path type);
               };
-            crateCargoPath = "${path}/Cargo.toml";
-            crateCargoToml = builtins.fromTOML (builtins.readFile crateCargoPath);
-            name = crateCargoToml.package.name;
+            cargoPath = "${path}/Cargo.toml";
+            cargoToml = builtins.fromTOML (builtins.readFile cargoPath);
+            name = cargoToml.package.name;
             crateNixFilePath =
               if config.rust-project.crateNixFile == null
               then null
@@ -42,7 +42,7 @@
           }
         )
         { }
-        (lib.fileset.toList (globset.lib.globs src cargoToml.workspace.members))
+        cargoToml.workspace.members
     else
     # Read single package crate from top-level Cargo.toml
       {

--- a/nix/modules/flake-module.nix
+++ b/nix/modules/flake-module.nix
@@ -29,15 +29,6 @@ in
               });
             };
 
-            globset = lib.mkOption {
-              default = rustFlakeInputs.globset;
-              internal = true;
-              readOnly = true;
-              description = ''
-                Reference to the globset flake input.
-              '';
-            };
-
             crane-lib = lib.mkOption {
               type = lib.types.lazyAttrsOf lib.types.raw;
               description = ''


### PR DESCRIPTION
This PR reverts the changes introduced in #34, which used the `globset` flake to handle wildcard patterns in Cargo workspace members.

**Motivation:** https://github.com/juspay/rust-flake/pull/38#discussion_r2196783164

### Changes:
- Reverted globset integration from #34.
- Added a custom glob matching function for `Cargo.toml` workspace members.
