### PR TITLE
feat: support workspace level versioning in crates

### DIFF
--- a/nix/modules/crate.nix
+++ b/nix/modules/crate.nix
@@ -72,11 +72,11 @@
 
       outputs =
         let
-          inherit (rust-project) toolchain src crane-lib;
+          inherit (rust-project) src crane-lib;
           inherit (config) crane cargoToml;
 
           name = cargoToml.package.name;
-          version = cargoToml.package.version;
+          # version = cargoToml.package.version;
           description = cargoToml.package.description
             or (builtins.throw "Missing description in ${name}'s Cargo.toml");
 
@@ -85,7 +85,7 @@
           # option?
           craneBuild = rec {
             args = crane.args // {
-              inherit src version;
+              inherit src;
               pname = name;
               cargoExtraArgs = "-p ${name}";
               # glib-sys fails to build on linux without this

--- a/nix/modules/crate.nix
+++ b/nix/modules/crate.nix
@@ -76,7 +76,6 @@
           inherit (config) crane cargoToml;
 
           name = cargoToml.package.name;
-          # version = cargoToml.package.version;
           description = cargoToml.package.description
             or (builtins.throw "Missing description in ${name}'s Cargo.toml");
 


### PR DESCRIPTION
Parsing versions in rust-flake fail for cases where the version derives its value from the workspace root, for example:
```
[package]
version.workspace = true
```
The fix for this would be to not specify the version in rust-flake and let cargo resolve crate versions.