### PR TITLE
devshell: Supress warnings by removing nested list

### DIFF
--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -15,9 +15,9 @@
       '';
       buildInputs = [
         pkgs.libiconv
-      ] ++ lib.mapAttrsToList (_: crate: crate.crane.args.buildInputs) config.rust-project.crates;
+      ] ++ lib.concatMap (crate: crate.crane.args.buildInputs) (lib.attrValues config.rust-project.crates);
       packages = [
         toolchain
-      ] ++ lib.mapAttrsToList (_: crate: crate.crane.args.nativeBuildInputs) config.rust-project.crates;
+      ] ++ lib.concatMap (crate: crate.crane.args.nativeBuildInputs) (lib.attrValues config.rust-project.crates);
     };
 }


### PR DESCRIPTION
Supress following warnings:
```
evaluation warning: Dependency of package 'rust-flake-devshell' uses a nested list in attribute 'buildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
evaluation warning: Dependency of package 'rust-flake-devshell' uses a nested list in attribute 'buildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
evaluation warning: Dependency of package 'rust-flake-devshell' uses a nested list in attribute 'buildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
evaluation warning: Dependency of package 'rust-flake-devshell' uses a nested list in attribute 'nativeBuildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
evaluation warning: Dependency of package 'rust-flake-devshell' uses a nested list in attribute 'nativeBuildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
evaluation warning: Dependency of package 'rust-flake-devshell' uses a nested list in attribute 'nativeBuildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
```