### PR TITLE
Auto-merge weekly flake.lock PRs on Vira success

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   example-lock:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -20,3 +23,9 @@ jobs:
           pr-labels: |
             automated
           branch: "update_flake_lock"
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr=$(gh pr list --head update_flake_lock --state open --json number --jq '.[0].number')
+          [ -n "$pr" ] && gh pr merge "$pr" --auto --squash || echo "no PR to auto-merge"


### PR DESCRIPTION
The weekly `update-flake-lock` workflow opens a PR that Vira builds and signs off (`signoff/vira/aarch64-darwin` + `signoff/vira/x86_64-linux`), but it then **sits waiting for a manual merge** every week (e.g. #83).

The `main` ruleset already *requires* both Vira checks, and the repo already *allows* auto-merge — the only missing piece was that nobody ever **enabled** auto-merge on the bot's PR. This adds an `Enable auto-merge` step (plus the `contents`/`pull-requests` write permissions it needs) right after the flake.lock update, so each weekly PR is flagged for squash-merge and GitHub merges it the moment Vira goes green. No more manual clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)